### PR TITLE
fix: Using * for imports can affect compile-time

### DIFF
--- a/src/secur3dit/filters/Filters.java
+++ b/src/secur3dit/filters/Filters.java
@@ -5,9 +5,12 @@
 
 package secur3dit.filters;
 
-import java.awt.*;
+import java.awt.AlphaComposite;
 import java.awt.Color;
-import java.awt.geom.*;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 
 public class Filters {


### PR DESCRIPTION
The import directive should not be burdened with unwanted classes.
When a class does not exist in the given file, the compiler searches
for the class from the list of imports which implies that using * for
imports is increasing the search space for the compiler. Another reason
to avoid * is to prevent naming conflicts if any.