### PR TITLE
feat: Posterize an image

### DIFF
--- a/src/secur3dit/filters/Filters.java
+++ b/src/secur3dit/filters/Filters.java
@@ -412,4 +412,35 @@ public class Filters {
         boxBlur(source, target, intensity + 1);
         return target;
     }
+
+    /**
+     * Takes an image and returns a posterized version of it. 
+     * Posterization achieves this by reducing the distinct pixels in 
+     * an image. We apply the Helpers.reducePixel() method on R,G,B 
+     * value of every pixel. 
+     */
+    public static BufferedImage posterize(BufferedImage image) {
+        
+        BufferedImage result = Helpers.deepCopy(image);
+        int width = image.getWidth();
+        int height = image.getHeight();
+    
+        for (int i = 0; i < height; ++i) {
+            for (int j = 0; j < width; ++j) {
+                // get the color
+                Color originalColor = new Color(result.getRGB(j, i));
+
+                // reduce the pixels
+                int red = Helpers.reducePixel(originalColor.getRed());
+                int green = Helpers.reducePixel(originalColor.getGreen());
+                int blue = Helpers.reducePixel(originalColor.getBlue());
+
+                // apply the color
+                Color finalColor = new Color(red, green, blue);
+                result.setRGB(j, i, finalColor.getRGB());
+            }
+        }
+
+        return result;
+    }
 }

--- a/src/secur3dit/filters/Helpers.java
+++ b/src/secur3dit/filters/Helpers.java
@@ -144,4 +144,34 @@ public class Helpers {
             }
         }
     }
+
+    /**
+     * Takes a pixel value and reduces it
+     * to one of the 4 distinct values. If
+     * the value is invalid, the method returns 
+     * 255. The rules for deciding the values and 
+     * the number of distinct values can vary depending
+     * upon implementation. The idea here is to reduce 
+     * the number of distinct colors used in an image. 
+     */
+    static int reducePixel(int pixel) {
+
+        if (pixel < 64) {
+            return 0;
+        }
+
+        if (pixel >= 64 && pixel < 128) {
+            return 64;
+        }
+
+        if (pixel >= 128 && pixel < 192) {
+            return 128;
+        }
+
+        if (pixel >= 192 && pixel < 255) {
+            return 192;
+        }
+
+        return 255;
+    }
 };


### PR DESCRIPTION
Image posterizing depends upon reducing the number of distinct pixels
in an image. The rules for pixel reduction can vary. We reduce a pixel
in constant time by keeping only 4 possible output values for each input
value ranging from 0-255. The choice of the values and the number of
values is arbitrary. A possible future addition could be to let the end
user decide this.