### PR TITLE
fix: brighten/darken not reflecting any change

### DIFF
--- a/src/secur3dit/filters/Helpers.java
+++ b/src/secur3dit/filters/Helpers.java
@@ -240,10 +240,6 @@ final class Helpers {
      */
     static void lightDial(BufferedImage image, double dial) throws ArrayIndexOutOfBoundsException {
 
-        if (dial > 1.0 || dial < 1.0) {
-            return;
-        }
-
         double limit = (dial > 0.0) ? 255.0 : 0.0;
 
         for (int i = 0; i < image.getHeight(); ++i) {


### PR DESCRIPTION
This bug was caused by an improper and wasteful check in
Helpers.lightDial method. It is improper because the floating-point
comparison is not accurate. It is wasteful since an improper input value
will end up throwing an exception and the UI code (responsible for calling
brighten/darken method) handles the input itself.